### PR TITLE
macros: add assignment form to pin! (#2274)

### DIFF
--- a/tokio/src/macros/pin.rs
+++ b/tokio/src/macros/pin.rs
@@ -97,6 +97,30 @@
 ///     }
 /// }
 /// ```
+///
+/// Because assigning to a variable followed by pinning is common, there is also
+/// a variant of the macro that supports doing both in one go.
+///
+/// ```
+/// use tokio::{pin, select};
+///
+/// async fn my_async_fn() {
+///     // async logic here
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     pin! {
+///         let future1 = my_async_fn();
+///         let future2 = my_async_fn();
+///     }
+///
+///     select! {
+///         _ = &mut future1 => {}
+///         _ = &mut future2 => {}
+///     }
+/// }
+/// ```
 #[macro_export]
 macro_rules! pin {
     ($($x:ident),*) => { $(
@@ -108,5 +132,13 @@ macro_rules! pin {
         let mut $x = unsafe {
             $crate::macros::support::Pin::new_unchecked(&mut $x)
         };
-    )* }
+    )* };
+    ($(
+            let $x:ident = $init:expr;
+    )*) => {
+        $(
+            let $x = $init;
+            crate::pin!($x);
+        )*
+    };
 }

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,0 +1,15 @@
+use tokio::pin;
+
+async fn one() {}
+async fn two() {}
+
+#[tokio::test]
+async fn multi_pin() {
+    pin! {
+        let f1 = one();
+        let f2 = two();
+    }
+
+    (&mut f1).await;
+    (&mut f2).await;
+}


### PR DESCRIPTION
Allows combining assignment to a binding and pinning it.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
